### PR TITLE
Add deprecate notice, recommend users to use attache instead [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED
+
+S3FF is no longer used or maintained by Jolly Good Code. Please use [attache][attache] instead.
+
+Thanks!
+
+[attache]: https://github.com/choonkeat/attache
+
 # S3FF
 
 Using [s3_file_field][] with [paperclip][].


### PR DESCRIPTION
<kbd>[View Rendered README.md](https://github.com/jollygoodcode/s3ff/blob/defb88bcf068750e3594b5fe9fa8c9c5f63f9d47/README.md)</kbd>
